### PR TITLE
Atualiza Evento e EventoController para se adequarem ao novo uso de "data_inicio" e "data_fim".

### DIFF
--- a/app/Http/Controllers/EventoController.php
+++ b/app/Http/Controllers/EventoController.php
@@ -19,20 +19,29 @@ class EventoController extends Controller
             'tipo' => 'required|string',
             'valor' => 'required|numeric',
             'descricao' => 'required|string',
-            'datas' => 'required|date|after_or_equal:today',
+            'data_inicio' => 'required|date|after_or_equal:today',
+            'data_fim' => 'required|date|after_or_equal:data_inicio',
             'numOfertasDiarias' => 'required|integer',
         ], [
-            'datas.after_or_equal' => 'A data precisa ser hoje ou futura!',
+            'data_inicio.after_or_equal' => 'A data de início precisa ser hoje ou futura!',
+            'data_fim.after_or_equal' => 'A data final precisa ser igual ou maior que a data de início!',
         ]);
 
-        //Verifica se já existe um evento com o mesmo tipo e data
+        // Verifica se já existe evento com o mesmo tipo e intervalo que conflita
         $existeEvento = Evento::where('tipo', $request->tipo)
-            ->where('datas', $request->datas)
+            ->where(function($query) use ($request) {
+                $query->whereBetween('data_inicio', [$request->data_inicio, $request->data_fim])
+                      ->orWhereBetween('data_fim', [$request->data_inicio, $request->data_fim])
+                      ->orWhere(function($q) use ($request) {
+                          $q->where('data_inicio', '<=', $request->data_inicio)
+                            ->where('data_fim', '>=', $request->data_fim);
+                      });
+            })
             ->exists();
 
         if ($existeEvento) {
             return response()->json([
-                'message' => 'Já existe um evento cadastrado com o mesmo tipo e data.'
+                'message' => 'Já existe um evento cadastrado com o mesmo tipo e intervalo de datas que conflita.'
             ], 422);
         }
 
@@ -43,7 +52,6 @@ class EventoController extends Controller
             'data' => $evento
         ], 201);
     }
-
 
     public function show($id)
     {
@@ -57,22 +65,32 @@ class EventoController extends Controller
             'tipo' => 'required|string',
             'valor' => 'required|numeric',
             'descricao' => 'required|string',
-            'datas' => 'required|date|after_or_equal:today',
+            'data_inicio' => 'required|date|after_or_equal:today',
+            'data_fim' => 'required|date|after_or_equal:data_inicio',
             'numOfertasDiarias' => 'required|integer',
         ], [
-            'datas.after_or_equal' => 'A data precisa ser hoje ou futura!',
+            'data_inicio.after_or_equal' => 'A data de início precisa ser hoje ou futura!',
+            'data_fim.after_or_equal' => 'A data final precisa ser igual ou maior que a data de início!',
         ]);
 
         $evento = Evento::findOrFail($id);
 
-        // Impede atualizar para uma data já existente em outro evento
-        $existeEvento = Evento::where('datas', $request->datas)
+        // Impede conflito de datas com outros eventos do mesmo tipo
+        $existeEvento = Evento::where('tipo', $request->tipo)
             ->where('id', '!=', $id)
+            ->where(function($query) use ($request) {
+                $query->whereBetween('data_inicio', [$request->data_inicio, $request->data_fim])
+                      ->orWhereBetween('data_fim', [$request->data_inicio, $request->data_fim])
+                      ->orWhere(function($q) use ($request) {
+                          $q->where('data_inicio', '<=', $request->data_inicio)
+                            ->where('data_fim', '>=', $request->data_fim);
+                      });
+            })
             ->exists();
 
         if ($existeEvento) {
             return response()->json([
-                'message' => 'Já existe outro evento cadastrado nesta data.'
+                'message' => 'Já existe outro evento cadastrado no intervalo de datas informado.'
             ], 422);
         }
 
@@ -83,7 +101,6 @@ class EventoController extends Controller
             'data' => $evento
         ]);
     }
-
 
     public function destroy($id)
     {

--- a/app/Models/Evento.php
+++ b/app/Models/Evento.php
@@ -10,7 +10,8 @@ class Evento extends Model
         'tipo',
         'valor',
         'descricao',
-        'datas',
+        'data_inicio',
+        'data_fim',
         'numOfertasDiarias',
     ];
 }


### PR DESCRIPTION
Esta PR ajusta o modelo Evento e o EventoController para uso após a alteração feita na estrutura da tabela de eventos. Agora são utilizados os campos `data_inicio` e `data_fim` no lugar do antigo campo `datas`.

Alterei a lógica e testei via api, funcionando normalmente!
